### PR TITLE
Fix BN_zero usage in SetHex

### DIFF
--- a/src/BigNum.h
+++ b/src/BigNum.h
@@ -529,9 +529,10 @@ public:
     }
     if (fNegative)
     {
-      BIGNUM* zero=0;;
+      BIGNUM* zero = BN_new();
       BN_zero(zero);
       BN_sub(this->bn_, zero, this->bn_);
+      BN_free(zero);
     }
   }
 


### PR DESCRIPTION
## Summary
- allocate a BIGNUM before BN_zero and clean up afterwards
- leave build warnings unaffected by this section

## Testing
- `make -f makefile.unix -k` *(fails: BN_zero_ex void conversion in crypto/Key.cpp)*

------
https://chatgpt.com/codex/tasks/task_e_6875b5ecb5d88320a2789f454f03195b