### PR TITLE
Fix BN_zero call in Key.cpp

### DIFF
--- a/src/BigNum.h
+++ b/src/BigNum.h
@@ -529,9 +529,10 @@ public:
     }
     if (fNegative)
     {
-      BIGNUM* zero=0;;
+      BIGNUM* zero = BN_new();
       BN_zero(zero);
       BN_sub(this->bn_, zero, this->bn_);
+      BN_free(zero);
     }
   }
 

--- a/src/crypto/Key.cpp
+++ b/src/crypto/Key.cpp
@@ -257,11 +257,7 @@ int ECDSA_SIG_recover_key_GFp(EC_KEY *eckey, ECDSA_SIG *ecsig, const unsigned ch
 
   zero = BN_CTX_get(ctx);
 
-  if (!BN_zero(zero))
-  {
-    ret=-1;
-    goto err;
-  }
+  BN_zero(zero);
 
   if (!BN_mod_sub(e, zero, e, order, ctx))
   {


### PR DESCRIPTION
## Summary
- correct misuse of `BN_zero` in `Key.cpp`

## Testing
- `make -f src/makefile.unix -k` *(fails: missing submodule build dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6875b5ecb5d88320a2789f454f03195b