### PR TITLE
Fix SetHex memory leak and null checks

### DIFF
--- a/src/BigNum.h
+++ b/src/BigNum.h
@@ -524,12 +524,21 @@ public:
       std::ostringstream os;
       os << n;
       BIGNUM* n_big = BN_new();
+      if (n_big == NULL)
+      {
+        throw bignum_error("CBigNum::SetHex() : BN_new failed");
+      }
       BN_dec2bn(&n_big, os.str().c_str());
       BN_add(this->bn_, this->bn_, n_big);
+      BN_free(n_big);
     }
     if (fNegative)
     {
       BIGNUM* zero = BN_new();
+      if (zero == NULL)
+      {
+        throw bignum_error("CBigNum::SetHex() : BN_new failed");
+      }
       BN_zero(zero);
       BN_sub(this->bn_, zero, this->bn_);
       BN_free(zero);


### PR DESCRIPTION
## Summary
- free temporary `BIGNUM` in `CBigNum::SetHex`
- check `BN_new` allocation

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_6875c8d5af008320a81725786066981a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability by adding checks for failed memory allocation during number processing, preventing potential crashes.
  * Enhanced resource management by ensuring proper cleanup of allocated memory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->