### PR TITLE
Update Python utilities for Python 3

### DIFF
--- a/contrib/qt_translations.py
+++ b/contrib/qt_translations.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 # Helpful little script that spits out a comma-separated list of
 # language codes for Qt icons that should be included
@@ -18,5 +18,5 @@ d2 = sys.argv[2]
 l1 = set([ re.search(r'qt_(.*).qm', f).group(1) for f in glob.glob(os.path.join(d1, 'qt_*.qm')) ])
 l2 = set([ re.search(r'bitcoin_(.*).qm', f).group(1) for f in glob.glob(os.path.join(d2, 'bitcoin_*.qm')) ])
 
-print ",".join(sorted(l1.intersection(l2)))
+print(",".join(sorted(l1.intersection(l2))))
 

--- a/share/qt/make_spinner.py
+++ b/share/qt/make_spinner.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 # W.J. van der Laan, 2011
 # Make spinning .mng animation from a .png
 # Requires imagemagick 6.7+
@@ -26,7 +26,7 @@ def frame_to_filename(frame):
     return path.join(TMPDIR, TMPNAME % frame)
 
 frame_files = []
-for frame in xrange(NUMFRAMES):
+for frame in range(NUMFRAMES):
     rotation = (frame + 0.5) / NUMFRAMES * 360.0
     if CLOCKWISE:
         rotation = -rotation


### PR DESCRIPTION
## Summary
- update shebangs to python3
- switch `xrange` to `range`
- use `print()` function for translations helper
- verify scripts compile with Python 3

## Testing
- `python3 -m py_compile share/qt/make_spinner.py contrib/qt_translations.py`

------
https://chatgpt.com/codex/tasks/task_e_6876709255dc83209a58c5ce4d0ddd22