### PR TITLE
Replace CNode new/delete with smart pointers

### DIFF
--- a/src/CheckPoints.cpp
+++ b/src/CheckPoints.cpp
@@ -200,8 +200,8 @@ bool AcceptPendingSyncCheckpoint()
 
     if (!checkpointMessage.IsNull())
     {
-      BOOST_FOREACH(CNode* pnode, vNodes)
-      checkpointMessage.RelayTo(pnode);
+      BOOST_FOREACH(CNodeRef pnode, vNodes)
+      checkpointMessage.RelayTo(pnode.get());
     }
 
     return true;
@@ -385,8 +385,8 @@ bool SendSyncCheckpoint(uint256 hashCheckpoint)
 
   {
     LOCK(cs_vNodes);
-    BOOST_FOREACH(CNode* pnode, vNodes)
-    checkpoint.RelayTo(pnode);
+    BOOST_FOREACH(CNodeRef pnode, vNodes)
+    checkpoint.RelayTo(pnode.get());
   }
 
   return true;


### PR DESCRIPTION
## Summary
- manage `CNode` lifetimes with `std::shared_ptr`
- update node vectors and helper functions to use smart pointers
- remove manual reference counting and deletion logic

## Testing
- `make -f makefile.unix -j2` *(fails: `db_cxx.h` missing)*

------
https://chatgpt.com/codex/tasks/task_e_6876742b67fc8320bc51aa7c6a6a7995