### PR TITLE
Fix Base validator inheritance and implement validate

### DIFF
--- a/src/validation/base/Base.cpp
+++ b/src/validation/base/Base.cpp
@@ -1,3 +1,7 @@
 #include "Base.h"
 
-bool Base::validate() { }
+bool Base::validate()
+{
+    // TODO: add actual validation logic
+    return true;
+}

--- a/src/validation/base/Base.h
+++ b/src/validation/base/Base.h
@@ -1,7 +1,7 @@
 #pragma once
 #include "validation/interface/Validator.h"
 
-class Base : publish Validator
+class Base : public Validator
 {
   public:
     Base() = default;


### PR DESCRIPTION
## Summary
- fix typo to inherit from `Validator`
- implement `Base::validate` with stub

## Testing
- `g++ -std=c++11 -c src/validation/base/Base.cpp -Isrc -Wall -Wextra -o /tmp/base.o`

------
https://chatgpt.com/codex/tasks/task_e_6876910a05888320b1c1ec87d96758b9