### PR TITLE
Remove using-directive from Script.h

### DIFF
--- a/src/Script.h
+++ b/src/Script.h
@@ -11,8 +11,6 @@
 #include "KeyStore.h"
 #include "BigNum.h"
 
-using namespace std;
-
 typedef std::vector<unsigned char> valtype;
 
 class CTransaction;
@@ -20,7 +18,7 @@ class CTransaction;
 std::string Hash160ToAddress(uint160 hash160);
 extern bool AddressToHash160(const char* psz, uint160& hash160Ret);
 extern bool AddressToHash160(const std::string& str, uint160& hash160Ret);
-extern string Hash160ToAddress(uint160 hash160);
+extern std::string Hash160ToAddress(uint160 hash160);
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 1000000;
 static const unsigned int MAX_OP_RETURN_RELAY = 40;
 


### PR DESCRIPTION
## Summary
- clean up std namespace usage in `src/Script.h`

## Testing
- `make -f makefile.unix` *(fails: `dvmc_message` not declared)*

------
https://chatgpt.com/codex/tasks/task_e_687691a139e8832086600d8c2f5241da

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved namespace clarity by explicitly qualifying standard library types and removing implicit namespace usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->