### PR TITLE
Remove using namespace from headers

### DIFF
--- a/src/Coordinate.h
+++ b/src/Coordinate.h
@@ -4,6 +4,9 @@
 //XXXX PRAGMA
 
 #include "InterfaceCrypt.h"
+#include <string>
+#include <vector>
+#include <algorithm>
 
 class CoordinateVector : InterfaceCrypt
 {
@@ -12,7 +15,7 @@ public:
   {
   }
 
-  CoordinateVector(string& s)
+  CoordinateVector(std::string& s)
   {
     this->r_ = s;
   };
@@ -27,23 +30,23 @@ public:
   }
   inline virtual void open() {}
   inline virtual void close() {}
-  inline virtual string alias()
+  inline virtual std::string alias()
   {
     return "";
   }
-  inline virtual string ctrl_()
+  inline virtual std::string ctrl_()
   {
     return this->r_;
   }
-  inline virtual void ctrl(string& c)
+  inline virtual void ctrl(std::string& c)
   {
     this->r_ = c;
   }
 
-  inline bool mapNode(string l, int& p)
+  inline bool mapNode(std::string l, int& p)
   {
-    vector<string>::iterator iter;
-    iter=find(this->d1_.begin(),this->d1_.end(),l);
+    std::vector<std::string>::iterator iter;
+    iter=std::find(this->d1_.begin(),this->d1_.end(),l);
     if(iter != this->d1_.end())
     {
       p = iter - this->d1_.begin();
@@ -61,19 +64,19 @@ public:
   {
     return this->d1_.size() == 0;
   }
-  inline string& domainImage()
+  inline std::string& domainImage()
   {
     return this->d0_.back();
   }
-  inline string& codomainImage()
+  inline std::string& codomainImage()
   {
     return this->d1_.back();
   }
-  inline void domain(string s)
+  inline void domain(std::string s)
   {
     this->d0_.push_back(s);
   }
-  inline void codomain(string s)
+  inline void codomain(std::string s)
   {
     this->d1_.push_back(s);
   }
@@ -85,10 +88,10 @@ public:
   )
 
 private:
-  string r_;
-  string locator_;
-  vector<string> d0_;
-  vector<string> d1_;
+  std::string r_;
+  std::string locator_;
+  std::vector<std::string> d0_;
+  std::vector<std::string> d1_;
 };
 
 #endif

--- a/src/CoordinatePatch.h
+++ b/src/CoordinatePatch.h
@@ -4,6 +4,8 @@
 
 #include "InterfaceCrypt.h"
 #include "State.h"
+#include <string>
+#include <vector>
 
 class CoordinatePatch : InterfaceCrypt
 {
@@ -12,7 +14,7 @@ public:
   {
   }
 
-  CoordinatePatch(string& s)
+  CoordinatePatch(std::string& s)
   {
     this->r_ = s;
   };
@@ -40,24 +42,24 @@ public:
   inline virtual void burstTx(BurstBuffer& d) { }
   inline virtual void open() {}
   inline virtual void close() {}
-  inline virtual string alias()
+  inline virtual std::string alias()
   {
     return "";
   }
-  inline virtual string ctrl_()
+  inline virtual std::string ctrl_()
   {
     return this->r_;
   }
-  inline virtual void ctrl(string& c)
+  inline virtual void ctrl(std::string& c)
   {
     this->r_ = c;
   }
 
 
 private:
-  string r_;
-  string locator_;
-  vector<unsigned int> connectionVector_;
+  std::string r_;
+  std::string locator_;
+  std::vector<unsigned int> connectionVector_;
 };
 
 #endif

--- a/src/InterfaceCrypt.h
+++ b/src/InterfaceCrypt.h
@@ -1,6 +1,5 @@
 #pragma once
 
-using namespace::std;
 
 class InterfaceCrypt
 {
@@ -8,8 +7,8 @@ public:
   virtual int sig() = 0;
   virtual void open() = 0;
   virtual void close() = 0;
-  virtual string alias() = 0;
-  virtual string ctrl_() = 0;
-  virtual void ctrl(string& c) = 0;
+  virtual std::string alias() = 0;
+  virtual std::string ctrl_() = 0;
+  virtual void ctrl(std::string& c) = 0;
 };
 

--- a/src/NodeEx.h
+++ b/src/NodeEx.h
@@ -3,7 +3,6 @@
 #include "Twister.h"
 #include <vector>
 
-using namespace::std;
 
 struct __BASE__
 {
@@ -99,7 +98,7 @@ private:
   __BASE__ g_;
   int s_base_;
   int corr_;
-  vector<unsigned char> nList;
+  std::vector<unsigned char> nList;
   NRelay rel_;
 };
 
@@ -150,6 +149,6 @@ private:
   int lMap_;
   int locatorRelay_;
   NRelay relay_;
-  vector<unsigned char> buffer_;
+  std::vector<unsigned char> buffer_;
 };
 

--- a/src/RayShade.h
+++ b/src/RayShade.h
@@ -1,21 +1,23 @@
 #pragma once
 
 #include "InterfaceCrypt.h"
+#include <string>
+#include <vector>
 
 
 struct __pq__
 {
-  vector<unsigned char> __fq1;
-  vector<unsigned char> __fq9;
-  vector<unsigned char> __fq0;
-  vector<unsigned char> __fq2;
-  vector<unsigned char> __fq5;
+  std::vector<unsigned char> __fq1;
+  std::vector<unsigned char> __fq9;
+  std::vector<unsigned char> __fq0;
+  std::vector<unsigned char> __fq2;
+  std::vector<unsigned char> __fq5;
 };
 
 struct __inv__
 {
-  vector<unsigned char> __inv7;
-  vector<unsigned char> __inv1;
+  std::vector<unsigned char> __inv7;
+  std::vector<unsigned char> __inv1;
 };
 
 class RayShade : InterfaceCrypt
@@ -28,7 +30,7 @@ public:
   {
   }
 
-  RayShade(string& s)
+  RayShade(std::string& s)
   {
     this->tgt_ = s;
   };
@@ -43,15 +45,15 @@ public:
   }
   inline virtual void open() {}
   inline virtual void close() {}
-  inline virtual string alias()
+  inline virtual std::string alias()
   {
     return "";
   }
-  inline virtual string ctrl_()
+  inline virtual std::string ctrl_()
   {
     return this->tgt_;
   }
-  inline virtual void ctrl(string& c)
+  inline virtual void ctrl(std::string& c)
   {
     this->tgt_ = c;
   }
@@ -77,15 +79,15 @@ public:
     return this->o_ ;
   }
 
-  inline virtual void ctrlDtx(string& o)
+  inline virtual void ctrlDtx(std::string& o)
   {
     this->vtx_ = o;
   }
-  inline virtual void streamID(vector<unsigned char> o)
+  inline virtual void streamID(std::vector<unsigned char> o)
   {
     this->stream_id = o;
   }
-  inline virtual vector<unsigned char> streamID()
+  inline virtual std::vector<unsigned char> streamID()
   {
     return this->stream_id;
   }
@@ -106,9 +108,9 @@ private:
   }
 
   int l7_;
-  string tgt_;
+  std::string tgt_;
   uint160 o_;
-  string vtx_;
-  vector<unsigned char> stream_id;
+  std::string vtx_;
+  std::vector<unsigned char> stream_id;
 };
 

--- a/src/Relay.h
+++ b/src/Relay.h
@@ -5,6 +5,7 @@
 #include "Coordinate.h"
 #include "CoordinatePatch.h"
 #include "RayShade.h"
+#include <string>
 
 class Relay : InterfaceCrypt
 {
@@ -13,7 +14,7 @@ public:
   {
   }
 
-  Relay(string& s)
+  Relay(std::string& s)
   {
     this->r_ = s;
   };
@@ -28,15 +29,15 @@ public:
   }
   inline virtual void open() {}
   inline virtual void close() {}
-  inline virtual string alias()
+  inline virtual std::string alias()
   {
     return "";
   }
-  inline virtual string ctrl_()
+  inline virtual std::string ctrl_()
   {
     return this->r_;
   }
-  inline virtual void ctrl(string& c)
+  inline virtual void ctrl(std::string& c)
   {
     this->r_ = c;
   }
@@ -48,7 +49,7 @@ public:
   )
 
 private:
-  string r_;
-  string locator_;
+  std::string r_;
+  std::string locator_;
 };
 

--- a/src/Script.h
+++ b/src/Script.h
@@ -11,7 +11,6 @@
 #include "KeyStore.h"
 #include "BigNum.h"
 
-using namespace std;
 
 typedef std::vector<unsigned char> valtype;
 
@@ -20,7 +19,7 @@ class CTransaction;
 std::string Hash160ToAddress(uint160 hash160);
 extern bool AddressToHash160(const char* psz, uint160& hash160Ret);
 extern bool AddressToHash160(const std::string& str, uint160& hash160Ret);
-extern string Hash160ToAddress(uint160 hash160);
+extern std::string Hash160ToAddress(uint160 hash160);
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 1000000;
 static const unsigned int MAX_OP_RETURN_RELAY = 40;
 

--- a/src/Script.h
+++ b/src/Script.h
@@ -19,7 +19,6 @@ class CTransaction;
 std::string Hash160ToAddress(uint160 hash160);
 extern bool AddressToHash160(const char* psz, uint160& hash160Ret);
 extern bool AddressToHash160(const std::string& str, uint160& hash160Ret);
-extern std::string Hash160ToAddress(uint160 hash160);
 static const unsigned int MAX_SCRIPT_ELEMENT_SIZE = 1000000;
 static const unsigned int MAX_OP_RETURN_RELAY = 40;
 

--- a/src/Twister.cpp
+++ b/src/Twister.cpp
@@ -55,7 +55,7 @@ unsigned char base(unsigned char a, unsigned char (*s)(unsigned char), int pos)
 {
   return (*s)(pos)^a;
 }
-void transHomExt(vector<unsigned char>& data, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char))
+void transHomExt(std::vector<unsigned char>& data, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char))
 {
   for(unsigned i = 0; i<data.size(); i++)
   {
@@ -69,7 +69,7 @@ void transHomExt(vector<unsigned char>& data, unsigned char (*f)(unsigned char),
     data[i] = d;
   }
 }
-void transHom(vector<unsigned char>& data, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char))
+void transHom(std::vector<unsigned char>& data, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char))
 {
   for(unsigned i = 0; i<data.size(); i++)
   {
@@ -83,7 +83,7 @@ void transHom(vector<unsigned char>& data, unsigned char (*f)(unsigned char), un
     data[i] = d;
   }
 }
-void trans(vector<unsigned char>& data, unsigned char (*f)(unsigned char))
+void trans(std::vector<unsigned char>& data, unsigned char (*f)(unsigned char))
 {
   for(unsigned i = 0; i<data.size(); i++)
   {
@@ -97,9 +97,9 @@ void trans(vector<unsigned char>& data, unsigned char (*f)(unsigned char))
     data[i] = d;
   }
 }
-vector<double> f_dist(vector<unsigned char>& in)
+std::vector<double> f_dist(std::vector<unsigned char>& in)
 {
-  vector<double> fdist;
+  std::vector<double> fdist;
   fdist.resize(256);
 
   for(unsigned i = 0; i<in.size(); i++)
@@ -114,7 +114,7 @@ vector<double> f_dist(vector<unsigned char>& in)
 
   return fdist;
 }
-double s_entropy(vector<double>& v)
+double s_entropy(std::vector<double>& v)
 {
   double entropy = 0;
   double p;
@@ -133,7 +133,7 @@ double s_entropy(vector<double>& v)
 
   return -entropy;
 }
-void rms(const string& s, string& r)
+void rms(const std::string& s, std::string& r)
 {
   for(unsigned int i=0; i<s.size(); i++)
   {
@@ -183,11 +183,11 @@ void hPerm(int s, int n, void (*p)(int), void (*inv)(int, int), void (*center)(i
     }
   }
 }
-double ic(const string& t)
+double ic(const std::string& t)
 {
-  string text;
+  std::string text;
   rms(t, text);
-  vector<double> freq(256,0);
+  std::vector<double> freq(256,0);
 
   for(unsigned int i=0; i<text.size(); i++)
   {
@@ -243,25 +243,25 @@ std::tuple<int, int, int> extended_gcd(int __alpha, int __beta, int (*col)(int x
 {
   if(__alpha == 0)
   {
-    return make_tuple(__beta,0,1);
+    return std::make_tuple(__beta,0,1);
   }
 
   int __com=0;
   int x=0;
   int y=0;
-  tie(__com, x, y) = extended_gcd(__beta%__alpha, __alpha, col);
-  return make_tuple(__com, y-(__beta/__alpha)*x, x);
+  std::tie(__com, x, y) = extended_gcd(__beta%__alpha, __alpha, col);
+  return std::make_tuple(__com, y-(__beta/__alpha)*x, x);
 }
 std::tuple<int, int, int> extended_gcd(int __alpha, int __beta)
 {
   if(__alpha == 0)
   {
-    return make_tuple(__beta,0,1);
+    return std::make_tuple(__beta,0,1);
   }
 
   int __com=0;
   int x=0;
   int y=0;
-  tie(__com, x, y) = extended_gcd(__beta%__alpha, __alpha);
-  return make_tuple(__com, y-(__beta/__alpha)*x, x);
+  std::tie(__com, x, y) = extended_gcd(__beta%__alpha, __alpha);
+  return std::make_tuple(__com, y-(__beta/__alpha)*x, x);
 }

--- a/src/Twister.h
+++ b/src/Twister.h
@@ -11,23 +11,19 @@
 #include<tuple>
 
 
-using namespace::std;
-
-using namespace boost::multiprecision;
-using namespace boost::random;
 
 
 
-typedef boost::random::independent_bits_engine<boost::random::mt19937, 256, cpp_int> GEN__;
+typedef boost::random::independent_bits_engine<boost::random::mt19937, 256, boost::multiprecision::cpp_int> GEN__;
 typedef struct displ
 {
   int sect_;
   GEN__ strm_;
-  cpp_int offset_;
-  cpp_int gen_mat_test_;
-  cpp_dec_float_50 scale_;
-  cpp_dec_float_50 range_;
-  vector<int> coord_;
+  boost::multiprecision::cpp_int offset_;
+  boost::multiprecision::cpp_int gen_mat_test_;
+  boost::multiprecision::cpp_dec_float_50 scale_;
+  boost::multiprecision::cpp_dec_float_50 range_;
+  std::vector<int> coord_;
 } view;
 
 
@@ -36,7 +32,7 @@ typedef struct ex_mix
 {
   int pos_;
   GEN__ g_;
-  vector<displ> descTable_;
+  std::vector<displ> descTable_;
 } mix;
 
 
@@ -62,10 +58,10 @@ typedef struct FI2__
   ex_mix desc_;
   ex_mix path_;
   ex_mix desc1_;
-  map<FI1__, displ> transMap_;
-  map<FI1__, displ> internMap_;
-  map<FI2__, displ> extTransMap_;
-  map<FI2__, displ> torTransMap_;
+  std::map<FI1__, displ> transMap_;
+  std::map<FI1__, displ> internMap_;
+  std::map<FI2__, displ> extTransMap_;
+  std::map<FI2__, displ> torTransMap_;
 } fi2;
 
 typedef struct R1_mtx_rotate
@@ -82,12 +78,12 @@ typedef struct R1_mtx_rotate
 
 typedef struct TransitionElement
 {
-  vector<double> ent_indicator_;
+  std::vector<double> ent_indicator_;
   FI2__ key_center_;
-  vector<R1_mtx_rotate> morph_l_;
-  vector<FI1__> reference_;
-  vector<FI2__> cbase_;
-  vector<FI2__> key_l_;
+  std::vector<R1_mtx_rotate> morph_l_;
+  std::vector<FI1__> reference_;
+  std::vector<FI2__> cbase_;
+  std::vector<FI2__> key_l_;
 } transelt;
 
 typedef struct Spectra
@@ -97,22 +93,22 @@ typedef struct Spectra
   FI2__ dim_;
 } spec;
 
-vector<double> f_dist(vector<unsigned char>& in);
-double s_entropy(vector<double> v);
+std::vector<double> f_dist(std::vector<unsigned char>& in);
+double s_entropy(std::vector<double> v);
 
-void trans(vector<unsigned char>, unsigned char (*f)(unsigned char));
-void transHom(vector<unsigned char>, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char));
-void transHomExt(vector<unsigned char>, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char));
+void trans(std::vector<unsigned char>, unsigned char (*f)(unsigned char));
+void transHom(std::vector<unsigned char>, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char));
+void transHomExt(std::vector<unsigned char>, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char));
 class SpecExec
 {
 public:
   SpecExec() {}
   ~SpecExec() {}
 
-  virtual double entropy(vector<double> v);
-  virtual double sect(vector<double> v);
-  virtual double sect_outer(vector<double> v);
-  virtual double trans_ext(vector<double> v);
+  virtual double entropy(std::vector<double> v);
+  virtual double sect(std::vector<double> v);
+  virtual double sect_outer(std::vector<double> v);
+  virtual double trans_ext(std::vector<double> v);
 
 };
 
@@ -135,18 +131,18 @@ private:
   FI1__ mix;
 };
 
-double ic(const string& );
+double ic(const std::string& );
 
-void trans(vector<unsigned char>& data, unsigned char (*f)(unsigned char));
-double s_entropy(vector<double>&) ;
+void trans(std::vector<unsigned char>& data, unsigned char (*f)(unsigned char));
+double s_entropy(std::vector<double>&) ;
 void switchIO(unsigned char (*p)(unsigned char, unsigned char), unsigned char);
-void transHom(vector<unsigned char>&, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char));
+void transHom(std::vector<unsigned char>&, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char));
 void multiChan(unsigned char* (*p)(unsigned char, unsigned char), unsigned char);
 void hPerm(int s, int n, void (*p)(int), void (*inv)(int, int), void (*center)(int));
 double sw(double weight, int i, int j, int (*inv)(int, int));
-void rms(const string&, string& );
-vector<double> f_dist(vector<unsigned char>&);
-void transHomExt(vector<unsigned char>&, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char));
+void rms(const std::string&, std::string& );
+std::vector<double> f_dist(std::vector<unsigned char>&);
+void transHomExt(std::vector<unsigned char>&, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char));
 int outer_sect(int (*s)(int), int (*t)(int), int, int);
 
 

--- a/src/Twister.h
+++ b/src/Twister.h
@@ -93,12 +93,6 @@ typedef struct Spectra
   FI2__ dim_;
 } spec;
 
-std::vector<double> f_dist(std::vector<unsigned char>& in);
-double s_entropy(std::vector<double> v);
-
-void trans(std::vector<unsigned char>, unsigned char (*f)(unsigned char));
-void transHom(std::vector<unsigned char>, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char));
-void transHomExt(std::vector<unsigned char>, unsigned char (*f)(unsigned char), unsigned char (*g)(unsigned char));
 class SpecExec
 {
 public:

--- a/src/dions/Reference.h
+++ b/src/dions/Reference.h
@@ -3,7 +3,6 @@
 #include "Constants.h"
 #include "Dions.h"
 
-using namespace std;
 
 class Reference
 {
@@ -22,7 +21,7 @@ public:
   }
 
 private:
-  string INIT_REF ;
-  string m_;
+  std::string INIT_REF ;
+  std::string m_;
 };
 


### PR DESCRIPTION
## Summary
- eliminate `using namespace` from several headers
- qualify standard and boost types in headers
- update corresponding source and header files

## Testing
- `make -f makefile.unix` *(fails: boost headers not found, then compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_6876aa4de1f08320bc214a3b6ddea375

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated all user-facing interfaces to use fully qualified standard library types (e.g., `std::string`, `std::vector`) instead of unqualified names.
  * Removed global namespace usage for improved clarity and consistency.
  * Public method and constructor signatures now explicitly reference standard library types across various components.
  * No changes to application logic or behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->